### PR TITLE
Add AGENTS instructions for DEVELOPER.md maintenance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,4 @@ Treat any non-trivial task as major work.
 1. Before starting major work, read `DEVELOPER.md` to understand the project structure, constraints, and operational risks.
 2. Before starting major work, verify that `DEVELOPER.md` is still current: review repository changes since its last meaningful update, refresh the document if needed, and commit that `DEVELOPER.md` update before proceeding with the main task.
 3. After finishing your work, update `DEVELOPER.md` again if your changes affected architecture, behavior, workflows, integrations, or other developer-facing guidance.
+4. Preserve the existing code style and local conventions in the files you touch; do not make style-only changes or cleanup refactors unless explicitly asked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS.md
+
+Treat any non-trivial task as major work.
+
+1. Before starting major work, read `DEVELOPER.md` to understand the project structure, constraints, and operational risks.
+2. Before starting major work, verify that `DEVELOPER.md` is still current: review repository changes since its last meaningful update, refresh the document if needed, and commit that `DEVELOPER.md` update before proceeding with the main task.
+3. After finishing your work, update `DEVELOPER.md` again if your changes affected architecture, behavior, workflows, integrations, or other developer-facing guidance.


### PR DESCRIPTION
## Summary
- add a short `AGENTS.md` with guidance to read `DEVELOPER.md` before major work
- require verifying and refreshing `DEVELOPER.md` before major work when repository changes made it stale
- note that `DEVELOPER.md` should be updated after relevant changes are completed
- require agents to preserve the existing code style and local conventions unless asked to refactor
